### PR TITLE
Fix typos in comments

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -11,7 +11,7 @@ type NullBool struct {
 	b sql.NullBool
 }
 
-// NullBoolOf return NullBool that he value is set.
+// NullBoolOf return NullBool that the value is set.
 func NullBoolOf(value bool) NullBool {
 	var b NullBool
 	b.Set(value)

--- a/float64.go
+++ b/float64.go
@@ -12,7 +12,7 @@ type NullFloat64 struct {
 	f sql.NullFloat64
 }
 
-// NullFloat64Of return NullFloat64 that he value is set.
+// NullFloat64Of return NullFloat64 that the value is set.
 func NullFloat64Of(value float64) NullFloat64 {
 	var s NullFloat64
 	s.Set(value)

--- a/int64.go
+++ b/int64.go
@@ -12,7 +12,7 @@ type NullInt64 struct {
 	i sql.NullInt64
 }
 
-// NullInt64Of return NullInt64 that he value is set.
+// NullInt64Of return NullInt64 that the value is set.
 func NullInt64Of(value int64) NullInt64 {
 	var s NullInt64
 	s.Set(value)

--- a/string.go
+++ b/string.go
@@ -11,7 +11,7 @@ type NullString struct {
 	s sql.NullString
 }
 
-// NullStringOf return NullString that he value is set.
+// NullStringOf return NullString that the value is set.
 func NullStringOf(value string) NullString {
 	var s NullString
 	s.Set(value)

--- a/time.go
+++ b/time.go
@@ -13,7 +13,7 @@ type NullTime struct {
 	v bool // Valid is true if Time is not NULL
 }
 
-// NullTimeOf return NullTime that he value is set.
+// NullTimeOf return NullTime that the value is set.
 func NullTimeOf(value time.Time) NullTime {
 	var t NullTime
 	t.Set(value)


### PR DESCRIPTION
`he value` という表記がなされていました。 `the value` の誤植かと思われましたので PR を作成させていただきました。
些細な変更ですが、ご確認ください。