### PR TITLE
Make Valid method with value receiver for all value types to have Valid() interface

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -19,7 +19,7 @@ func NullBoolOf(value bool) NullBool {
 }
 
 // Valid return the value is valid. If true, it is not null value.
-func (b *NullBool) Valid() bool {
+func (b NullBool) Valid() bool {
 	return b.b.Valid
 }
 

--- a/float64.go
+++ b/float64.go
@@ -20,7 +20,7 @@ func NullFloat64Of(value float64) NullFloat64 {
 }
 
 // Valid return the value is valid. If true, it is not null value.
-func (f *NullFloat64) Valid() bool {
+func (f NullFloat64) Valid() bool {
 	return f.f.Valid
 }
 

--- a/int64.go
+++ b/int64.go
@@ -20,7 +20,7 @@ func NullInt64Of(value int64) NullInt64 {
 }
 
 // Valid return the value is valid. If true, it is not null value.
-func (i *NullInt64) Valid() bool {
+func (i NullInt64) Valid() bool {
 	return i.i.Valid
 }
 

--- a/string.go
+++ b/string.go
@@ -19,7 +19,7 @@ func NullStringOf(value string) NullString {
 }
 
 // Valid return the value is valid. If true, it is not null value.
-func (s *NullString) Valid() bool {
+func (s NullString) Valid() bool {
 	return s.s.Valid
 }
 

--- a/time.go
+++ b/time.go
@@ -21,7 +21,7 @@ func NullTimeOf(value time.Time) NullTime {
 }
 
 // Valid return the value is valid. If true, it is not null value.
-func (t *NullTime) Valid() bool {
+func (t NullTime) Valid() bool {
 	return t.v
 }
 


### PR DESCRIPTION
Every example in your repository contains value struct attributes, like 

```
type User struct {
	Name	nulltype.NullString `json:"name"`
}
```

and together with ozzo validation library and go1.18 generics feature, required validation can be expressed as 

```
type Validatable interface {
	Valid() bool
}

func validateNullable[V Validatable](value interface{}) error {
	var v, ok = value.(V)
	if !ok || !v.Valid() {
		return errors.New("can not be null")
	}
	return nil
}

validation.Field(&strct.Field, validation.By(validateNullable[nulltype.NullBool])),
```

but for some reason every null type has a pointer receiver in `Valid` method and it breaks type cast. Other way is to introduce reflect inside `validateNullable`, but I can not see a reason for `Valid` method to be pointer receiver, maybe you can explain it otherwise?